### PR TITLE
Add Pagefind search with Matomo tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ aliases = [
 ```
 
 This way, if the structure of the page changes, users will still be able to use their old links.
+
+## Search and analytics
+
+This project uses [Pagefind](https://pagefind.app) to build a search index after Hugo builds. Install dependencies and run:
+
+```
+npm install
+npm run build
+```
+
+The build script runs `hugo` followed by `pagefind` to create the `/public/pagefind` index. The search page reports queries and result counts to Matomo via `window._paq?.push(['trackSiteSearch', query, false, results.length]);`.

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,0 +1,5 @@
+---
+title: "Search"
+language: "En"
+layout: "search"
+---

--- a/content/no/search.md
+++ b/content/no/search.md
@@ -1,0 +1,5 @@
+---
+title: "Søk"
+language: "No"
+layout: "search"
+---

--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,5 @@
+---
+title: "Sök"
+language: "Se"
+layout: "search"
+---

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,0 +1,17 @@
+{{ partial "head.html" . }}
+<body>
+  {{ partial "header.html" . }}
+  <main class="main-default-single">
+    <div id="search"></div>
+  </main>
+  {{ partial "footer.html" . }}
+  <script src="https://cdn.jsdelivr.net/npm/pagefind@1/dist/pagefind-ui.js"></script>
+  <script>
+    const ui = new PagefindUI({ element: "#search", pagefindUrl: "/pagefind/" });
+    window.addEventListener('pagefind/search', (e) => {
+      const query = e.detail.term;
+      const results = e.detail.results || [];
+      window._paq?.push(['trackSiteSearch', query, false, results.length]);
+    });
+  </script>
+</body>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,8 +28,6 @@
 </div>
 
 <!-- CONTENT -->
-<!-- Pagefind search UI -->
-<div data-pagefind-search-ui></div>
 {{ if .Params.logobanner }}{{ partial "logobanner2.html" . }}{{ end }}
 {{ if .Params.logobannersaas }}{{ partial "logobanner-saas.html" . }}{{ end }}
 <main class="main-default-single">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -740,4 +740,7 @@
 <noscript>
     <link rel="stylesheet" href="{{ $faCSS.RelPermalink }}">
 </noscript>
+{{ if eq .Layout "search" }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pagefind@1/dist/pagefind-ui.css">
+{{ end }}
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,6 +17,7 @@
           <li><a id="main-menu-link-1" href='/{{ if eq $language "En" }}en/price{{ else if eq $language "No" }}no/pris{{ else }}pris{{ end }}'>{{ if eq $language "En" }}Price{{ else if eq $language "No" }}Pris{{ else }}Pris{{ end }}</a></li>
           <li><a id="main-menu-link-2" href='/latest/'>{{ if eq $language "En" }}News{{ else if eq $language "No" }}Aktuelt{{ else }}Aktuellt{{ end }}</a></li>
           <li><a id="main-menu-link-3" href='/{{ if eq $language "En" }}en/contact{{ else if eq $language "No" }}no/kontakt{{ else }}kontakt{{ end }}/'>{{ if eq $language "En" }}Contact{{ else if eq $language "No" }}Kontakt{{ else }}Kontakt{{ end }}</a></li>
+          <li><a id="main-menu-link-search" href='/{{ if eq $language "En" }}en/search{{ else if eq $language "No" }}no/search{{ else }}search{{ end }}/'>{{ if eq $language "En" }}Search{{ else if eq $language "No" }}Søk{{ else }}Sök{{ end }}</a></li>
           <!--<li><a id="main-menu-link-4" href='{{ if eq $language "No" }}tel:+4735688870{{ else }}tel:+46855107370{{ end }}' class="site-header-button" onclick="_paq.push(['trackEvent', 'Knapptryck', 'Telefonknapp']);">{{ if eq $language "No" }}35 68 88 70{{ else if eq $language "En" }}+46 855 107 370{{ else }}08-55 10 73 70{{ end }}</a></li>-->
           <li><a id="main-menu-link-5" href='mailto:hello@safespring.com' class="site-header-button-mail" onclick="_paq.push(['trackEvent', 'Knapptryck', 'Mailknapp']);">hello@safespring.com</a></li>
         </ul>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "description": "This repository contains the source code and Markdown content for the Safespring website, which can be found at https://www.safespring.com/.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "hugo && npx pagefind --source public"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "pagefind": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Add Pagefind build step and dependency.
- Create dedicated search layout using Pagefind UI and send queries to Matomo.
- Link header navigation to the new search page and load Pagefind styles only when needed.
- Document build and tracking setup in README.

## Testing
- `npm run build` *(fails: hugo: not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e877314c832795d4ab22ae02985a