### PR TITLE
Add Pagefind stylesheet to search layout

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,4 +1,5 @@
 {{ partial "head.html" . }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pagefind@1/dist/pagefind-ui.css">
 <body>
   {{ partial "header.html" . }}
   <main class="main-default-single">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -740,7 +740,4 @@
 <noscript>
     <link rel="stylesheet" href="{{ $faCSS.RelPermalink }}">
 </noscript>
-{{ if eq .Layout "search" }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pagefind@1/dist/pagefind-ui.css">
-{{ end }}
 </head>


### PR DESCRIPTION
## Summary
- include Pagefind UI CSS directly in the search layout
- remove redundant Pagefind CSS inclusion from the head partial

## Testing
- `apt-get update` *(fails: repository InRelease not signed)*
- `npm install` *(fails: 403 Forbidden from npm registry)*
- `npm run build` *(fails: hugo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f5b1a0c08327bbd271acbb314d15