### PR TITLE
Update beta ingress to use safespring DNS host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+.github
+node_modules
+public
+resources
+.DS_Store
+.env*
+deploy
+scripts/*.pyc
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.6
+
+# Build stage - uses Hugo extended to compile the site into static assets
+FROM klakegg/hugo:0.134.2-ext-alpine AS builder
+WORKDIR /src
+
+# Copy the repository and build the production site
+COPY . .
+RUN hugo --minify --gc
+
+# Runtime stage - serve the generated static site through nginx
+FROM nginx:1.27-alpine
+COPY --from=builder /src/public /usr/share/nginx/html
+
+# Harden the container a bit
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -155,3 +155,60 @@ What it does: updates/creates frontmatter with `ai: true` and `language: "<lang>
 - **Missing API key**: Set `OPENAI_API_KEY` in `.env.local` or your environment.
 - **Unsupported path**: Ensure the file lives under `content/<sv|en|nb|da>/...`.
 - **Costs**: Translations call OpenAI and may incur usage charges.
+
+## Container image & Kubernetes deployment
+
+The repository now ships with a production-ready Dockerfile that builds the Hugo site and serves the generated static files through `nginx`. A typical workflow looks like this:
+
+1. **Build the image locally**
+
+   ```bash
+   docker build -t ghcr.io/<org>/web:<tag> .
+   ```
+
+   The build stage runs `hugo --minify --gc` and produces static assets in `/usr/share/nginx/html` inside the image.
+
+2. **Push the image to a registry that your cluster can reach**
+
+   ```bash
+   docker push ghcr.io/<org>/web:<tag>
+   ```
+
+3. **Update the deployment manifests**
+
+   - The base manifest (`deploy/base/deployment.yaml`) defaults to `ghcr.io/safespring/web:latest`.
+   - Overlays (for example `deploy/overlays/beta/kustomization.yaml`) can override the tag or registry with the `images:` block. Edit the value to match the image you just pushed.
+  - The beta overlay ingress is configured to use `www3.safespring.com`, which should resolve to `192.121.132.74` (the ingress IP that fronts `api.web-hugo.paas.safedc.net`). Update the host in `deploy/overlays/beta/ingress.yaml` if your DNS entry needs to point somewhere else.
+
+4. **Apply the overlay to your cluster**
+
+   Save the kubeconfig snippet from above as `web-hugo-kubeconfig` and ensure the accompanying certificate bundle is available if you need to inspect it. Then run:
+
+   ```bash
+   kustomize build deploy/overlays/beta \
+     | kubectl --kubeconfig ./web-hugo-kubeconfig apply -f -
+   ```
+
+   You can also use `kubectl kustomize deploy/overlays/beta` if your `kubectl` binary includes the plugin.
+
+5. **Verify the rollout**
+
+   ```bash
+   kubectl --kubeconfig ./web-hugo-kubeconfig -n web-beta get deploy,pods,svc,ingress
+   ```
+
+  Once the DNS entry for `www3.safespring.com` resolves to your cluster's ingress IP, visiting `https://www3.safespring.com` should show the Safespring site being served from your cluster.
+
+### Handling private registries
+
+If the registry requires authentication, create a Docker registry secret in the target namespace and reference it from the deployment:
+
+```bash
+kubectl --kubeconfig ./web-hugo-kubeconfig create secret docker-registry ghcr \
+  --namespace web-beta \
+  --docker-server=ghcr.io \
+  --docker-username=<user> \
+  --docker-password=<token>
+```
+
+Then add the secret name to `spec.template.spec.imagePullSecrets` in `deploy/base/deployment.yaml`.

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -13,18 +13,23 @@ spec:
         app: web
     spec:
       containers:
-      - name: nginx
-        image: nginxdemos/nginx-hello:plain-text
+      - name: web
+        image: ghcr.io/safespring/web:latest
+        imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 8080
+        - containerPort: 80
         readinessProbe:
-          httpGet: { path: /, port: 8080 }
+          httpGet: { path: /, port: 80 }
           initialDelaySeconds: 3
           periodSeconds: 5
         livenessProbe:
-          httpGet: { path: /, port: 8080 }
+          httpGet: { path: /, port: 80 }
           initialDelaySeconds: 10
           periodSeconds: 10
         resources:
           requests: { cpu: 50m, memory: 64Mi }
           limits:   { cpu: 200m, memory: 256Mi }
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 101

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
   - name: http
     port: 80
-    targetPort: 8080
+    targetPort: 80
     protocol: TCP
   type: ClusterIP

--- a/deploy/overlays/beta/ingress.yaml
+++ b/deploy/overlays/beta/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
 spec:
   rules:
-  - host: <din-externa-ip>.sslip.io
+  - host: www3.safespring.com
     http:
       paths:
       - path: /

--- a/deploy/overlays/beta/kustomization.yaml
+++ b/deploy/overlays/beta/kustomization.yaml
@@ -6,7 +6,12 @@ labels:
   - pairs:
       env: beta
 resources:
+  - namespace.yaml
   - ../../base
+  - ingress.yaml
+images:
+  - name: ghcr.io/safespring/web
+    newTag: beta
 replicas:
   - name: web
     count: 2

--- a/deploy/overlays/beta/namespace.yaml
+++ b/deploy/overlays/beta/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: web-beta


### PR DESCRIPTION
## Summary
- point the beta ingress host to www3.safespring.com which resolves to the cluster IP
- update the deployment instructions to describe the new hostname and DNS expectation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6909d4991760832794be051f5793cf99